### PR TITLE
Update TabAnimationActivity.java

### DIFF
--- a/MaterialSample/app/src/main/java/com/suleiman/material/activities/TabAnimationActivity.java
+++ b/MaterialSample/app/src/main/java/com/suleiman/material/activities/TabAnimationActivity.java
@@ -46,6 +46,7 @@ public class TabAnimationActivity extends AppCompatActivity {
         tabLayout.setOnTabSelectedListener(new TabLayout.ViewPagerOnTabSelectedListener(viewPager) {
             @Override
             public void onTabSelected(TabLayout.Tab tab) {
+                super.onTabSelected(tab);
                 switch (tab.getPosition()) {
                     case 0:
                         showToast("One");
@@ -63,12 +64,12 @@ public class TabAnimationActivity extends AppCompatActivity {
 
             @Override
             public void onTabUnselected(TabLayout.Tab tab) {
-
+                super.onTabUnselected(tab);
             }
 
             @Override
             public void onTabReselected(TabLayout.Tab tab) {
-
+                super.onTabReselected(tab);
             }
         });
     }

--- a/MaterialSample/app/src/main/java/com/suleiman/material/activities/TabAnimationActivity.java
+++ b/MaterialSample/app/src/main/java/com/suleiman/material/activities/TabAnimationActivity.java
@@ -43,7 +43,7 @@ public class TabAnimationActivity extends AppCompatActivity {
         TabLayout tabLayout = (TabLayout) findViewById(R.id.tabanim_tabs);
         tabLayout.setupWithViewPager(viewPager);
 
-        tabLayout.setOnTabSelectedListener(new TabLayout.OnTabSelectedListener() {
+        tabLayout.setOnTabSelectedListener(new TabLayout.ViewPagerOnTabSelectedListener(viewPager) {
             @Override
             public void onTabSelected(TabLayout.Tab tab) {
                 switch (tab.getPosition()) {


### PR DESCRIPTION
In the case of `tabLayout.setOnTabSelectedListener(new TabLayout.OnTabSelectedListener()`, ViewPager won't change pages when tabs are clicked. By replacing `OnTabSelectedListener` by `ViewPagerOnTabSelectedListener`, this problem won't happen again. 

I think it's a bug of TabLayout. Or does it act in the right way?!
